### PR TITLE
Move Client.addScope and Search.findListingByIds to .coffee from .js

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ The Etsy API has two modes: public, and authenticated. Public mode only requires
 
 ```js
 var etsyjs = require('etsy-js');
-var client = etsyjs.client('your_api_key');
+var client = etsyjs.client({
+  key: 'your_api_key'
+});
 
 // direct API calls (GET / PUT / POST / DELETE)
 client.get('/users/sparkleprincess', {}, function (err, status, body, headers) {

--- a/README.md
+++ b/README.md
@@ -142,6 +142,15 @@ etsyUser.find(callback); //json
 
 # Development
 
+When making changes to etsy-js, edit the .coffee files in `src/`&mdash;*not* the .js files in `lib/`! The latter are what become available to users who install the npm package, and if you edit them, your changes may be overwritten by other contributors.
+
+## Compiling CoffeeScript to JavaScript
+```shell
+$ coffee --no-header -c -o lib/ src/
+```
+
+Make sure to run the above command in the cloned directory before committing your changes. Otherwise, those changes might not be exposed within the npm package.
+
 ## Running the tests
 ```js
 $ grunt test

--- a/lib/etsyjs/client.js
+++ b/lib/etsyjs/client.js
@@ -6,7 +6,7 @@
 
   request = require('request');
 
-  OAuth = require('oauth');
+  OAuth = require('OAuth');
 
   util = require('util');
 
@@ -120,7 +120,7 @@
           body = JSON.parse(body || '{}');
         } catch (_error) {
           err = _error;
-          console.dir("Error parsing response: " + body);
+          console.log("Error parsing response: " + body);
           return callback(err);
         }
       }
@@ -133,7 +133,7 @@
     Client.prototype.get = function() {
       var callback, params, path, _i;
       path = arguments[0], params = 3 <= arguments.length ? __slice.call(arguments, 1, _i = arguments.length - 1) : (_i = 1, []), callback = arguments[_i++];
-      console.dir("==> Client get request with params " + params);
+      console.log("==> Client get request with params " + params);
       if ((this.authenticatedToken != null) && (this.authenticatedSecret != null)) {
         return this.getAuthenticated.apply(this, [path].concat(__slice.call(params), [callback]));
       } else {
@@ -144,7 +144,7 @@
     Client.prototype.put = function(path, content, callback) {
       var url;
       url = this.buildUrl(path);
-      console.dir("==> Perform PUT request on " + url + " with " + (JSON.stringify(content)));
+      console.log("==> Perform PUT request on " + url + " with " + (JSON.stringify(content)));
       return this.etsyOAuth.put(url, this.authenticatedToken, this.authenticatedSecret, content, (function(_this) {
         return function(err, data, res) {
           if (err) {
@@ -158,7 +158,7 @@
     Client.prototype.post = function(path, content, callback) {
       var url;
       url = this.buildUrl(path);
-      console.dir("==> Perform POST request on " + url + " with " + (JSON.stringify(content)));
+      console.log("==> Perform POST request on " + url + " with " + (JSON.stringify(content)));
       return this.etsyOAuth.post(url, this.authenticatedToken, this.authenticatedSecret, content, (function(_this) {
         return function(err, data, res) {
           if (err) {
@@ -172,7 +172,7 @@
     Client.prototype["delete"] = function(path, callback) {
       var url;
       url = this.buildUrl(path);
-      console.dir("==> Perform DELETE request on " + url);
+      console.log("==> Perform DELETE request on " + url);
       return this.etsyOAuth["delete"](url, this.authenticatedToken, this.authenticatedSecret, (function(_this) {
         return function(err, data, res) {
           if (err) {
@@ -186,7 +186,7 @@
     Client.prototype.getUnauthenticated = function() {
       var callback, params, path, _i;
       path = arguments[0], params = 3 <= arguments.length ? __slice.call(arguments, 1, _i = arguments.length - 1) : (_i = 1, []), callback = arguments[_i++];
-      console.dir("==> Perform unauthenticated GET request");
+      console.log("==> Perform unauthenticated GET request");
       return this.request({
         uri: this.buildUrl.apply(this, [path].concat(__slice.call(params))),
         method: 'GET'
@@ -204,7 +204,7 @@
       var callback, params, path, url, _i;
       path = arguments[0], params = 3 <= arguments.length ? __slice.call(arguments, 1, _i = arguments.length - 1) : (_i = 1, []), callback = arguments[_i++];
       url = this.buildUrl.apply(this, [path].concat(__slice.call(params)));
-      console.dir("==> Perform authenticated GET request on " + url);
+      console.log("==> Perform authenticated GET request on " + url);
       return this.etsyOAuth.get(url, this.authenticatedToken, this.authenticatedSecret, (function(_this) {
         return function(err, data, res) {
           if (err) {
@@ -218,7 +218,7 @@
     Client.prototype.requestToken = function(callback) {
       return this.etsyOAuth.getOAuthRequestToken(function(err, oauth_token, oauth_token_secret) {
         var auth, loginUrl;
-        console.dir("==> Retrieving the request token");
+        console.log("==> Retrieving the request token");
         if (err) {
           return callback(err);
         }
@@ -235,7 +235,7 @@
     Client.prototype.accessToken = function(token, secret, verifier, callback) {
       return this.etsyOAuth.getOAuthAccessToken(token, secret, verifier, function(err, oauth_access_token, oauth_access_token_secret, results) {
         var accessToken;
-        console.dir("==> Retrieving the access token");
+        console.log("==> Retrieving the access token");
         accessToken = {
           token: oauth_access_token,
           tokenSecret: oauth_access_token_secret
@@ -244,14 +244,16 @@
       });
     };
 
-    /**
-    * Allows for adding scope to the requests.
-    * (ex: transactions_r, listings_r, etc..)
-    * @author : httpNick
-    */
+
+    /*
+    Allows for adding scope to the requests.
+    (ex: transactions_r, listings_r, etc..)
+    @author : httpNick
+     */
+
     Client.prototype.addScope = function(newScope) {
       return this.etsyOAuth._requestUrl += "%20" + newScope;
-    }
+    };
 
     return Client;
 

--- a/lib/etsyjs/search.js
+++ b/lib/etsyjs/search.js
@@ -5,30 +5,31 @@
     function Search(client) {
       this.client = client;
     }
-    
-    var responseHandler = function(cb, error_message) {
-      return function(err, status, body, headers) {
+
+    Search.prototype.findAllUsers = function(params, cb) {
+      return this.client.get("/users", params, function(err, status, body, headers) {
         if (err) {
           return cb(err);
         }
         if (status !== 200) {
-          return cb(new Error(error_message));
+          return cb(new Error('Search users error'));
         } else {
           return cb(null, body, headers);
         }
-      };
-    };
-
-    Search.prototype.findAllUsers = function(params, cb) {
-      return this.client.get("/users", params, responseHandler(cb, 'Search users error'));
+      });
     };
 
     Search.prototype.findAllListings = function(params, cb) {
-      return this.client.get("/listings/active", params, responseHandler(cb, 'Search listings error'));
-    };
-
-    Search.prototype.findListingByIds = function(ids, params, cb) {
-      return this.client.get("/listings/"+ids.join(','), params, responseHandler(cb, 'Search listings error'));
+      return this.client.get("/listings", params, function(err, status, body, headers) {
+        if (err) {
+          return cb(err);
+        }
+        if (status !== 200) {
+          return cb(new Error('Search listings error'));
+        } else {
+          return cb(null, body, headers);
+        }
+      });
     };
 
     return Search;

--- a/lib/etsyjs/search.js
+++ b/lib/etsyjs/search.js
@@ -32,6 +32,21 @@
       });
     };
 
+    Search.prototype.findListingByIds = function(ids, params, cb) {
+      var uriParam;
+      uriParam = Array.isArray(ids) ? ids.join(',') : ids;
+      return this.client.get("/listings/" + uriParam, params, function(err, status, body, headers) {
+        if (err) {
+          return cb(err);
+        }
+        if (status !== 200) {
+          return cb(new Error('Search listings error'));
+        } else {
+          return cb(null, body, headers);
+        }
+      });
+    };
+
     return Search;
 
   })();

--- a/lib/etsyjs/search.js
+++ b/lib/etsyjs/search.js
@@ -2,49 +2,37 @@
   var Search;
 
   Search = (function() {
+    var responseHandler;
+
     function Search(client) {
       this.client = client;
     }
 
-    Search.prototype.findAllUsers = function(params, cb) {
-      return this.client.get("/users", params, function(err, status, body, headers) {
+    responseHandler = function(cb, errorMessage) {
+      return function(err, status, body, headers) {
         if (err) {
           return cb(err);
         }
         if (status !== 200) {
-          return cb(new Error('Search users error'));
+          return cb(new Error(errorMessage));
         } else {
           return cb(null, body, headers);
         }
-      });
+      };
+    };
+
+    Search.prototype.findAllUsers = function(params, cb) {
+      return this.client.get("/users", params, responseHandler(cb, 'Search users error'));
     };
 
     Search.prototype.findAllListings = function(params, cb) {
-      return this.client.get("/listings", params, function(err, status, body, headers) {
-        if (err) {
-          return cb(err);
-        }
-        if (status !== 200) {
-          return cb(new Error('Search listings error'));
-        } else {
-          return cb(null, body, headers);
-        }
-      });
+      return this.client.get("/listings", params, responseHandler(cb, 'Search listings error'));
     };
 
     Search.prototype.findListingByIds = function(ids, params, cb) {
       var uriParam;
       uriParam = Array.isArray(ids) ? ids.join(',') : ids;
-      return this.client.get("/listings/" + uriParam, params, function(err, status, body, headers) {
-        if (err) {
-          return cb(err);
-        }
-        if (status !== 200) {
-          return cb(new Error('Search listings error'));
-        } else {
-          return cb(null, body, headers);
-        }
-      });
+      return this.client.get("/listings/" + uriParam, params, responseHandler(cb, 'Search listings error'));
     };
 
     return Search;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1471 @@
+{
+  "name": "etsy-js",
+  "version": "0.0.6",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
+    "accepts": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz",
+      "integrity": "sha1-W1AftPBwQwmWTM2wSBclQSCNqxo=",
+      "dev": true,
+      "requires": {
+        "mime-types": "1.0.2",
+        "negotiator": "0.4.7"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+      "dev": true,
+      "requires": {
+        "underscore": "1.7.0",
+        "underscore.string": "2.4.0"
+      },
+      "dependencies": {
+        "underscore.string": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+          "dev": true
+        }
+      }
+    },
+    "asn1": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+      "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
+      "optional": true
+    },
+    "assert-plus": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+      "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+      "optional": true
+    },
+    "assertion-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+      "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=",
+      "dev": true
+    },
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+      "optional": true
+    },
+    "aws-sign2": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+      "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
+      "optional": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "boom": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+      "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
+      "requires": {
+        "hoek": "0.9.1"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz",
+      "integrity": "sha1-u1RRnpXRB8vSQA520MqxRnM22SE=",
+      "dev": true
+    },
+    "chai": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-1.9.2.tgz",
+      "integrity": "sha1-Pxog+CsLnXQ3V30k1vErGmnTtZA=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.0",
+        "deep-eql": "0.1.3"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "coffee-script": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
+      "integrity": "sha1-YplqhheAx15tUGnROCJyO3NAS/w=",
+      "requires": {
+        "mkdirp": "0.3.5"
+      }
+    },
+    "coffeelint": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/coffeelint/-/coffeelint-1.16.0.tgz",
+      "integrity": "sha1-g9jtHa/eOmd95E57ihi+YHdh5tg=",
+      "dev": true,
+      "requires": {
+        "coffee-script": "1.11.1",
+        "glob": "7.1.2",
+        "ignore": "3.3.7",
+        "optimist": "0.6.1",
+        "resolve": "0.6.3",
+        "strip-json-comments": "1.0.4"
+      },
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.1.tgz",
+          "integrity": "sha1-vxxHrWREOg2V0S3ysUfMCk2q1uk=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
+      }
+    },
+    "coffeelint-stylish": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/coffeelint-stylish/-/coffeelint-stylish-0.1.2.tgz",
+      "integrity": "sha1-q1AaZENeIxcG2hOidSeraVcAq8k=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "text-table": "0.2.0"
+      }
+    },
+    "colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+    },
+    "combined-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+      "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+      "optional": true,
+      "requires": {
+        "delayed-stream": "0.0.5"
+      }
+    },
+    "commander": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
+      "integrity": "sha1-0bhvkB+LZL2UG96tr5JFMDk76Sg=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cookie": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
+      "integrity": "sha1-cv7D0k5Io0Mgc9kMEmQgBQYQBLE=",
+      "dev": true
+    },
+    "cookie-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.1.0.tgz",
+      "integrity": "sha1-L4JlqjtVczqF7vIH8OJTDD6M9wU=",
+      "dev": true,
+      "requires": {
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.3"
+      }
+    },
+    "cookie-signature": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz",
+      "integrity": "sha1-kc2ZfMUftkFZVzjGnNoCAyj1D/k=",
+      "dev": true
+    },
+    "cookiejar": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-1.3.0.tgz",
+      "integrity": "sha1-3QCzVnkCHpnL1OhVua0EGRNHR2U=",
+      "dev": true
+    },
+    "cryptiles": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+      "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
+      "optional": true,
+      "requires": {
+        "boom": "0.4.2"
+      }
+    },
+    "ctype": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
+      "optional": true
+    },
+    "dateformat": {
+      "version": "1.0.2-1.2.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
+      "dev": true
+    },
+    "debug": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
+      "integrity": "sha1-OElZHBDM5khHbDx8Li40FttZY8Q=",
+      "dev": true,
+      "requires": {
+        "ms": "0.6.2"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      }
+    },
+    "delayed-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+      "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
+      "optional": true
+    },
+    "diff": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
+      "integrity": "sha1-JLuwAcSn1VIhaefKvbLCgU7ZHPQ=",
+      "dev": true
+    },
+    "ee-first": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz",
+      "integrity": "sha1-bJjECJq+y1p7hcGsRJqmA9Oz2r4=",
+      "dev": true
+    },
+    "emitter-component": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.0.0.tgz",
+      "integrity": "sha1-8E3Rj8PcPpp0y8DzELCIZm5MAW8=",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
+      "integrity": "sha1-GBoobq05ejmpKFfPsdQwUuNWv/A=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+      "dev": true
+    },
+    "eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "express": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.4.5.tgz",
+      "integrity": "sha1-Xy8wLydxh6vXIcOjbkTYbF4/A+s=",
+      "dev": true,
+      "requires": {
+        "accepts": "1.0.7",
+        "buffer-crc32": "0.2.3",
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.4",
+        "debug": "1.0.2",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.2",
+        "merge-descriptors": "0.0.2",
+        "methods": "1.0.1",
+        "parseurl": "1.0.1",
+        "path-to-regexp": "0.1.2",
+        "proxy-addr": "1.0.1",
+        "qs": "0.6.6",
+        "range-parser": "1.0.0",
+        "send": "0.4.3",
+        "serve-static": "1.2.3",
+        "type-is": "1.2.1",
+        "utils-merge": "1.0.0",
+        "vary": "0.1.0"
+      },
+      "dependencies": {
+        "cookie-signature": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz",
+          "integrity": "sha1-Dt0iKG46ERuaKnDbNj6SXoZ/aso=",
+          "dev": true
+        }
+      }
+    },
+    "express-session": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.3.1.tgz",
+      "integrity": "sha1-waJehukaH0LNRGZzU26DgdW3MiI=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "0.2.1",
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.3",
+        "debug": "1.0.2",
+        "on-headers": "0.0.0",
+        "uid2": "0.0.3",
+        "utils-merge": "1.0.0"
+      },
+      "dependencies": {
+        "buffer-crc32": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
+          "integrity": "sha1-vj5TgvwCttYySVasGvmKqYsIU0w=",
+          "dev": true
+        }
+      }
+    },
+    "faye-websocket": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
+      "integrity": "sha1-wUxbO/FNdBf/v9mQwKdJXNnzN7w=",
+      "dev": true
+    },
+    "findup-sync": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+      "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+      "dev": true,
+      "requires": {
+        "glob": "3.2.11",
+        "lodash": "2.4.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "minimatch": "0.3.0"
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        }
+      }
+    },
+    "finished": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz",
+      "integrity": "sha1-QWCOr639ZWg7RqEiC8Sx7D2u3Ng=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.0.3"
+      }
+    },
+    "forever-agent": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+      "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
+    },
+    "form-data": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+      "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
+      "optional": true,
+      "requires": {
+        "async": "0.9.2",
+        "combined-stream": "0.0.7",
+        "mime": "1.2.11"
+      }
+    },
+    "formidable": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
+      "integrity": "sha1-Kz9MQRy7X91pXESEPiojUUpDIxo=",
+      "dev": true
+    },
+    "fresh": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz",
+      "integrity": "sha1-lzHc9WeMf660T7kDxPct9VGH+nc=",
+      "dev": true
+    },
+    "fs-extra": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.8.1.tgz",
+      "integrity": "sha1-Dld5/7/t9RG8dVWVx/A8BtS0Po0=",
+      "dev": true,
+      "requires": {
+        "jsonfile": "1.1.1",
+        "mkdirp": "0.3.5",
+        "ncp": "0.4.2",
+        "rimraf": "2.2.8"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "gaze": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+      "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
+      "dev": true,
+      "requires": {
+        "globule": "0.1.0"
+      }
+    },
+    "getobject": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "1.2.3",
+        "inherits": "1.0.2",
+        "minimatch": "0.2.14"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+          "dev": true
+        }
+      }
+    },
+    "globule": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+      "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
+      "dev": true,
+      "requires": {
+        "glob": "3.1.21",
+        "lodash": "1.0.2",
+        "minimatch": "0.2.14"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+          "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
+          "dev": true
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
+      "integrity": "sha1-3i1mE20ALhErpw8/EMMc98NQsto=",
+      "dev": true
+    },
+    "grunt": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
+      "dev": true,
+      "requires": {
+        "async": "0.1.22",
+        "coffee-script": "1.3.3",
+        "colors": "0.6.2",
+        "dateformat": "1.0.2-1.2.3",
+        "eventemitter2": "0.4.14",
+        "exit": "0.1.2",
+        "findup-sync": "0.1.3",
+        "getobject": "0.1.0",
+        "glob": "3.1.21",
+        "grunt-legacy-log": "0.1.3",
+        "grunt-legacy-util": "0.2.0",
+        "hooker": "0.2.3",
+        "iconv-lite": "0.2.11",
+        "js-yaml": "2.0.5",
+        "lodash": "0.9.2",
+        "minimatch": "0.2.14",
+        "nopt": "1.0.10",
+        "rimraf": "2.2.8",
+        "underscore.string": "2.2.1",
+        "which": "1.0.9"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+          "dev": true
+        },
+        "coffee-script": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+          "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-coffeelint": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/grunt-coffeelint/-/grunt-coffeelint-0.0.16.tgz",
+      "integrity": "sha1-0iPUIwWmuXdqtbehQuFFP4hmK5s=",
+      "dev": true,
+      "requires": {
+        "coffeelint": "1.16.0",
+        "coffeelint-stylish": "0.1.2"
+      }
+    },
+    "grunt-contrib-coffee": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-coffee/-/grunt-contrib-coffee-0.10.1.tgz",
+      "integrity": "sha1-7SLGgp9FiqjqR/hnaEM+mBMUAYY=",
+      "dev": true,
+      "requires": {
+        "chalk": "0.4.0",
+        "coffee-script": "1.7.1",
+        "lodash": "2.4.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "1.0.0",
+            "has-color": "0.1.7",
+            "strip-ansi": "0.1.1"
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-contrib-watch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
+      "integrity": "sha1-ZP3LolpjX1tNobbOb5DaCutuPxU=",
+      "dev": true,
+      "requires": {
+        "async": "0.2.10",
+        "gaze": "0.5.2",
+        "lodash": "2.4.2",
+        "tiny-lr-fork": "0.0.5"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-log": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+      "dev": true,
+      "requires": {
+        "colors": "0.6.2",
+        "grunt-legacy-log-utils": "0.1.1",
+        "hooker": "0.2.3",
+        "lodash": "2.4.2",
+        "underscore.string": "2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-log-utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+      "dev": true,
+      "requires": {
+        "colors": "0.6.2",
+        "lodash": "2.4.2",
+        "underscore.string": "2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+      "dev": true,
+      "requires": {
+        "async": "0.1.22",
+        "exit": "0.1.2",
+        "getobject": "0.1.0",
+        "hooker": "0.2.3",
+        "lodash": "0.9.2",
+        "underscore.string": "2.2.1",
+        "which": "1.0.9"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-mocha-test": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.10.2.tgz",
+      "integrity": "sha1-PeXc+ZPkN1vhrxkfj1u9H1clbUc=",
+      "dev": true,
+      "requires": {
+        "fs-extra": "0.8.1",
+        "hooker": "0.2.3",
+        "mocha": "1.18.2"
+      }
+    },
+    "grunt-release": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/grunt-release/-/grunt-release-0.7.0.tgz",
+      "integrity": "sha1-vI7MJLxGoQp8UGV/GvXyy97DhjQ=",
+      "dev": true,
+      "requires": {
+        "q": "1.0.1",
+        "semver": "2.0.11",
+        "shelljs": "0.1.4",
+        "superagent": "0.15.7"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+      "dev": true
+    },
+    "hawk": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+      "integrity": "sha1-uQuxaYByhUEdp//LjdJZhQLTtS0=",
+      "optional": true,
+      "requires": {
+        "boom": "0.4.2",
+        "cryptiles": "0.2.2",
+        "hoek": "0.9.1",
+        "sntp": "0.2.4"
+      }
+    },
+    "hoek": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
+    },
+    "hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+      "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+      "optional": true,
+      "requires": {
+        "asn1": "0.1.11",
+        "assert-plus": "0.1.5",
+        "ctype": "0.5.3"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+      "dev": true
+    },
+    "ignore": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz",
+      "integrity": "sha1-ah/T2FT1ACllw017vNm0qNSwRn4=",
+      "dev": true
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "js-yaml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+      "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+      "dev": true,
+      "requires": {
+        "argparse": "0.1.16",
+        "esprima": "1.0.4"
+      }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonfile": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.1.1.tgz",
+      "integrity": "sha1-2k/WrXfxolUgPqY8e8Mtwx72RDM=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "merge-descriptors": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz",
+      "integrity": "sha1-w2pSp4FDdRPFcnXzndnTF1FKyMc=",
+      "dev": true
+    },
+    "methods": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz",
+      "integrity": "sha1-dbyRlD3/19oDfPPusO1zoAN80Us=",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+    },
+    "mime-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+      "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+    },
+    "mocha": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.18.2.tgz",
+      "integrity": "sha1-gAhI+PeITGHu/PoqJzBLqeVEbQs=",
+      "dev": true,
+      "requires": {
+        "commander": "2.0.0",
+        "debug": "1.0.2",
+        "diff": "1.0.7",
+        "glob": "3.2.3",
+        "growl": "1.7.0",
+        "jade": "0.26.3",
+        "mkdirp": "0.3.5"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "2.0.3",
+            "inherits": "2.0.3",
+            "minimatch": "0.2.14"
+          }
+        },
+        "graceful-fs": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+          "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+      "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw=",
+      "dev": true
+    },
+    "nconf": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.6.9.tgz",
+      "integrity": "sha1-lXDvFe1vmuays8jV5xtm0xk81mE=",
+      "dev": true,
+      "requires": {
+        "async": "0.2.9",
+        "ini": "1.3.5",
+        "optimist": "0.6.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz",
+          "integrity": "sha1-32MGD789Myhqdqr21Vophtn/hhk=",
+          "dev": true
+        },
+        "optimist": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz",
+          "integrity": "sha1-aUJIJvNAX3nxQub8PZrljU27kgA=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.3"
+          }
+        }
+      }
+    },
+    "ncp": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+      "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
+      "dev": true
+    },
+    "negotiator": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz",
+      "integrity": "sha1-pBYPcXfsgGc4Yx0NMFIyXaQqvcg=",
+      "dev": true
+    },
+    "nock": {
+      "version": "0.28.3",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-0.28.3.tgz",
+      "integrity": "sha1-Y4KStN6WmWsD4cgi8eFOM+XuDr0=",
+      "dev": true,
+      "requires": {
+        "propagate": "0.2.2"
+      }
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.1.1"
+      }
+    },
+    "noptify": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
+      "integrity": "sha1-WPZUpz2XU98MUdlobckhBKZ/S7s=",
+      "dev": true,
+      "requires": {
+        "nopt": "2.0.0"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
+          "integrity": "sha1-ynQW8gpeP5w7hhgPlilfo9C1Lg0=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.1.1"
+          }
+        }
+      }
+    },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+    },
+    "oauth-sign": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
+      "integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4=",
+      "optional": true
+    },
+    "on-headers": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-0.0.0.tgz",
+      "integrity": "sha1-7igX+DRDJXhc2cLfKyQrvBfK9MQ=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      }
+    },
+    "parseurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz",
+      "integrity": "sha1-Llfc5u/dN8NRhwEDCUTCK/OIt7Q=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.2.tgz",
+      "integrity": "sha1-mysVH5zDAYye6lDKlXKeBXgXErQ=",
+      "dev": true
+    },
+    "prettyjson": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.0.0.tgz",
+      "integrity": "sha1-iRGlWa/qLS1bd3wchfqNPfR72HU=",
+      "requires": {
+        "colors": "0.6.2",
+        "minimist": "0.0.8"
+      }
+    },
+    "propagate": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.2.2.tgz",
+      "integrity": "sha1-F6EW0l2vIJRCbX1oRNJiMsnWkms=",
+      "dev": true
+    },
+    "proxy-addr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz",
+      "integrity": "sha1-x8Vm1etOP61n7rnHfFVYzMObiKg=",
+      "dev": true,
+      "requires": {
+        "ipaddr.js": "0.1.2"
+      }
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "optional": true
+    },
+    "q": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz",
+      "integrity": "sha1-EYcq7t7okmgRCxCnGESP+xARKhQ=",
+      "dev": true
+    },
+    "qs": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+      "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc="
+    },
+    "range-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz",
+      "integrity": "sha1-pLJkz+C+XONqvjdlrJwqJIdG28A=",
+      "dev": true
+    },
+    "reduce-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
+      "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo=",
+      "dev": true
+    },
+    "request": {
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.34.0.tgz",
+      "integrity": "sha1-tdi5UmrdSi1GKfTUFxJFc5lkRa4=",
+      "requires": {
+        "aws-sign2": "0.5.0",
+        "forever-agent": "0.5.2",
+        "form-data": "0.1.4",
+        "hawk": "1.0.0",
+        "http-signature": "0.10.1",
+        "json-stringify-safe": "5.0.1",
+        "mime": "1.2.11",
+        "node-uuid": "1.4.8",
+        "oauth-sign": "0.3.0",
+        "qs": "0.6.6",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.3.0"
+      }
+    },
+    "resolve": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+      "integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+      "dev": true
+    },
+    "semver": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-2.0.11.tgz",
+      "integrity": "sha1-9R8H0D+lr3m+tTf8Bnp+FBeGzO0=",
+      "dev": true
+    },
+    "send": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.4.3.tgz",
+      "integrity": "sha1-lieyO3cH+/Y3ODHKxXkzMLWUtkA=",
+      "dev": true,
+      "requires": {
+        "debug": "1.0.2",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "range-parser": "1.0.0"
+      }
+    },
+    "serve-static": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.2.3.tgz",
+      "integrity": "sha1-k87Lw0Dweey4WJKB0dwxwmwM0Vg=",
+      "dev": true,
+      "requires": {
+        "escape-html": "1.0.1",
+        "parseurl": "1.0.1",
+        "send": "0.4.3"
+      }
+    },
+    "shelljs": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.1.4.tgz",
+      "integrity": "sha1-37vnjVbDwBaNL7eeEOzR28sH7A4=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "sntp": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+      "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
+      "optional": true,
+      "requires": {
+        "hoek": "0.9.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "superagent": {
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.15.7.tgz",
+      "integrity": "sha1-CVxwuK//vAcvFFjzloTUhU1jM6M=",
+      "dev": true,
+      "requires": {
+        "cookiejar": "1.3.0",
+        "debug": "0.7.4",
+        "emitter-component": "1.0.0",
+        "formidable": "1.0.14",
+        "methods": "0.0.1",
+        "mime": "1.2.5",
+        "qs": "0.6.5",
+        "reduce-component": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+          "dev": true
+        },
+        "methods": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz",
+          "integrity": "sha1-J3yQ+L7zlwlkWoNxxRw7bGSOBow=",
+          "dev": true
+        },
+        "mime": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.5.tgz",
+          "integrity": "sha1-nu0HMCKov14WyFZsaGe4gyv7+hM=",
+          "dev": true
+        },
+        "qs": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz",
+          "integrity": "sha1-KUsmjksNQlD23eGbO4s0k13/FO8=",
+          "dev": true
+        }
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "tiny-lr-fork": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
+      "integrity": "sha1-Hpnh4qhGm3NquX2X7vqYxx927Qo=",
+      "dev": true,
+      "requires": {
+        "debug": "0.7.4",
+        "faye-websocket": "0.4.4",
+        "noptify": "0.0.3",
+        "qs": "0.5.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+          "dev": true
+        },
+        "qs": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
+          "integrity": "sha1-MbGtBYVnZRxSaSFQa5qHk5EaA4Q=",
+          "dev": true
+        }
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "optional": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz",
+      "integrity": "sha1-rWgbaPUyGtKCfEz7G31d8s/pQu4=",
+      "optional": true
+    },
+    "type-detect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+      "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+      "dev": true
+    },
+    "type-is": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.2.1.tgz",
+      "integrity": "sha1-c9RICApPHdGKyx7v/2KWjFtdVKI=",
+      "dev": true,
+      "requires": {
+        "mime-types": "1.0.0"
+      },
+      "dependencies": {
+        "mime-types": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.0.tgz",
+          "integrity": "sha1-antKavLn2S+Xr+A/BHx4AejwAdI=",
+          "dev": true
+        }
+      }
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+      "dev": true
+    },
+    "underscore.string": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+      "dev": true
+    },
+    "vary": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-0.1.0.tgz",
+      "integrity": "sha1-3wlFiZ6TwMxb0YzIMh2dIedPYXY=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/src/etsyjs/client.coffee
+++ b/src/etsyjs/client.coffee
@@ -159,5 +159,13 @@ class Client
 
       callback null, accessToken
 
+  ###
+  Allows for adding scope to the requests.
+  (ex: transactions_r, listings_r, etc..)
+  @author : httpNick
+  ###
+  addScope: (newScope) ->
+    this.etsyOAuth._requestUrl += "%20#{newScope}"
+
 module.exports = (apiKey, options) ->
   new Client(apiKey, options)

--- a/src/etsyjs/search.coffee
+++ b/src/etsyjs/search.coffee
@@ -12,35 +12,28 @@ class Search
 
   constructor: (@client) ->
 
+  responseHandler = (cb, errorMessage) ->
+    return (err, status, body, headers) ->
+      return cb(err) if err
+      if status isnt 200
+        return cb(new Error(errorMessage))
+      else
+        return cb null, body, headers
+
   # Finds all Users whose name or username match the keywords parameter
   # '/users' GET
   findAllUsers: (params, cb) ->
-    @client.get "/users", params, (err, status, body, headers) ->
-      return cb(err) if err
-      if status isnt 200
-        cb(new Error('Search users error'))
-      else
-        cb null, body, headers
+    @client.get "/users", params, responseHandler(cb, 'Search users error')
 
   # Finds all listings
   # '/listings' GET
   findAllListings: (params, cb) ->
-    @client.get "/listings", params, (err, status, body, headers) ->
-      return cb(err) if err
-      if status isnt 200
-        cb(new Error('Search listings error'))
-      else
-        cb null, body, headers
+    @client.get "/listings", params, responseHandler(cb, 'Search listings error')
 
   # Finds listings with specified ids
   # '/listings/:listing_id' GET
   findListingByIds: (ids, params, cb) ->
     uriParam = if Array.isArray(ids) then ids.join(',') else ids
-    @client.get "/listings/" + uriParam, params, (err, status, body, headers) ->
-      return cb(err) if err
-      if status isnt 200
-        cb(new Error('Search listings error'))
-      else
-        cb null, body, headers
+    @client.get "/listings/" + uriParam, params, responseHandler(cb, 'Search listings error')
 
 module.exports = Search

--- a/src/etsyjs/search.coffee
+++ b/src/etsyjs/search.coffee
@@ -22,10 +22,21 @@ class Search
       else
         cb null, body, headers
 
-  # Finds all listings whose id match the params
+  # Finds all listings
   # '/listings' GET
   findAllListings: (params, cb) ->
     @client.get "/listings", params, (err, status, body, headers) ->
+      return cb(err) if err
+      if status isnt 200
+        cb(new Error('Search listings error'))
+      else
+        cb null, body, headers
+
+  # Finds listings with specified ids
+  # '/listings/:listing_id' GET
+  findListingByIds: (ids, params, cb) ->
+    uriParam = if Array.isArray(ids) then ids.join(',') else ids
+    @client.get "/listings/" + uriParam, params, (err, status, body, headers) ->
       return cb(err) if err
       if status isnt 200
         cb(new Error('Search listings error'))


### PR DESCRIPTION
I moved a function written by @httpNick in client.js to client.coffee. Similarly, I moved the findListingByIds function by @gsabran from search.js to search.coffee. To prevent issues like these in the future, I added CoffeeScript compilation instructions to the README.

The [solution](https://github.com/georgicodes/etsy-js/issues/2#issuecomment-76375137) to #2 fixes #10. I.e. the `options` parameter of the `Client` constructor should be a JSON object which specifies the API key within the `key` property. I also updated the README to reflect this in the public mode example.